### PR TITLE
Add example with https reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A fully containerized deployment of Seafile for Docker and Docker Swarm.
         1. [Example](#example)
 
 ## Features
-- Complete redesign of the [official Docker deployment](https://manual.seafile.com/docker/deploy%20seafile%20with%20docker/) with containerization best-practices in mind.
+- Complete redesign of the [official Docker deployment](https://manual.seafile.com/docker/deploy_seafile_with_docker/) with containerization best-practices in mind.
 - Runs seahub (frontend) and seafile server (backend) in separate containers, which commuicate with each other over TCP.
 - Cluster without pro edition.
 - Completely removed Nginx and self-implemented Let's Encrypt and replaced it with two caddy services.

--- a/README.md
+++ b/README.md
@@ -193,14 +193,23 @@ Networks:
 
 5. ***(Optional) Reverse Proxy***
     
-    Short version:
+    **Short version:**
+
     The caddy reverse proxy integrated in the deployment exposes **port 80**. Point your reverse proxy to that port.
     
-    Long version:
-    This deployment does by design **not** include a reverse proxy that is capable of https and Let's Encrypt, because usually Docker users already have some docker-based reverse proxy solution deployed, which does exactly that. If you're using Docker for a while already, you probably know what to do and you can skip this section.
+    If you don't have an existing reverse proxy that provides https, you can use this example as a starting point. It uses [nginx-proxy/nginx-proxy
+    ](https://github.com/nginx-proxy/nginx-proxy) as the reverse proxy and [nginx-proxy/acme-companion](https://github.com/nginx-proxy/acme-companion) to provide https via Let's Encrypt:
 
-    If you are new to Docker or you are interested in another revers proxy solution, have a look at those options:
-    - [jwilder/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) (recommended for beginners)
+    ```
+        wget https://raw.githubusercontent.com/ggogel/seafile-containerized/master/compose/docker-compose-https.yml
+    ```
+
+    **Long version:**
+
+    By default, this deployment does **not** include a reverse proxy that is capable of https and Let's Encrypt. This is by design, because usually Docker users already have some docker-based reverse proxy solution deployed, which does exactly that. If you're using Docker for a while already, you probably know what to do and you can skip this section.
+
+    If you are new to Docker or you are interested in another reverse proxy solution, have a look at those options:
+    - [nginx-proxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) (recommended for beginners)
         - popular solution for beginners
         - doesn't support Docker Swarm
         - automatic Let's Encrypt with plugin
@@ -219,7 +228,7 @@ Networks:
 
     Refer to the respective documentation. Often this is just one line you have to add to the `docker-compose.yml`. 
 
-    Example for [jwilder/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)
+    Example for [nginx-proxy/nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)
     ```
     seafile-caddy:
         image: ggogel/seafile-caddy:1.0.6

--- a/compose/docker-compose-https.yml
+++ b/compose/docker-compose-https.yml
@@ -1,0 +1,123 @@
+version: '3.8'
+services:
+  nginx-proxy:
+    container_name: nginx-proxy
+    image: nginxproxy/nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - certs:/etc/nginx/certs
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    networks:
+      - seafile-net
+      - default
+
+  nginx-proxy-acme:
+    image: nginxproxy/acme-companion
+    volumes:
+      - certs:/etc/nginx/certs
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - acme:/etc/acme.sh
+    environment:
+      - DEFAULT_EMAIL=me@example.com
+      - NGINX_PROXY_CONTAINER=nginx-proxy
+    depends_on:
+      - nginx-proxy
+    networks:
+      - seafile-net
+      - default
+
+  seafile-server:
+    image: ggogel/seafile-server:9.0.4
+    volumes:
+      - seafile-data:/shared
+    environment:
+      - DB_HOST=db
+      - DB_ROOT_PASSWD=db_dev
+      - TIME_ZONE=Europe/Berlin
+      - HTTPS=true
+      - SEAFILE_SERVER_HOSTNAME=seafile.mydomain.com # Mandatory on first deployment!
+      - GC_CRON=0 6 * * SUN # Garbage collection
+    depends_on:
+      - db
+      - memcached
+      - seafile-caddy
+    networks:
+      - seafile-net
+
+  seahub:
+    image: ggogel/seahub:9.0.4
+    volumes:
+      - seafile-data:/shared
+      - seahub-avatars:/shared/seafile/seahub-data/avatars
+      - seahub-custom:/shared/seafile/seahub-data/custom
+    environment:
+      - SEAFILE_ADMIN_EMAIL=me@example.com
+      - SEAFILE_ADMIN_PASSWORD=asecret
+    depends_on:
+      - seafile-server
+      - seafile-caddy
+      - seahub-media
+    networks:
+      - seafile-net
+
+  seahub-media:
+    image: ggogel/seahub-media:9.0.4
+    volumes:
+     - seahub-avatars:/usr/share/caddy/media/avatars
+     - seahub-custom:/usr/share/caddy/media/custom
+    depends_on:
+      - seafile-caddy
+    networks:
+      - seafile-net
+
+  db:
+    image: mariadb:10.7.1
+    environment:
+      - MYSQL_ROOT_PASSWORD=db_dev
+      - MYSQL_LOG_CONSOLE=true
+    volumes:
+      - seafile-mariadb:/var/lib/mysql
+    networks:
+      - seafile-net
+
+  memcached:
+    image: memcached:1.6.14
+    entrypoint: memcached -m 1024
+    networks:
+      - seafile-net
+
+  seafile-caddy:
+    image: ggogel/seafile-caddy:1.0.6
+    expose:
+      - "80"
+    networks:
+      - seafile-net
+    environment:
+      - VIRTUAL_PORT=80
+      - VIRTUAL_HOST=seafile.mydomain.com
+      - LETSENCRYPT_HOST=seafile.mydomain.com
+    depends_on:
+      - nginx-proxy
+      - nginx-proxy-acme
+
+networks:
+  seafile-net:
+    internal: true
+
+volumes:
+  seafile-data:
+  seafile-mariadb:
+  seahub-avatars:
+  seahub-custom:
+
+  # https://github.com/nginx-proxy/acme-companion
+  certs:
+  vhost:
+  html:
+  acme:


### PR DESCRIPTION
Not sure if this is something that you'd like to include in your repo, but... Docker is new to me, so it took me about a day to figure out how to setup a reverse proxy with HTTPS on top of `seafile-caddy`. I figured I'd send this PR to serve as an example to other users who are in a similar situation.

If it's helpful for context, in my use-case, Seafile gets deployed all by itself to a single droplet in DigitalOcean. So it's essentially... single-tenant at the VM layer? I figure that's a common use-case for self-hosting hobbyists.

I know I'm just scratching the surface in terms of what Docker can do, but I'm glad to have your deployment configuration to simplify deployment and upgrades. Thank you for putting this together!