### PR TITLE
Update docker file to support ENABLE_WEBDAV_SECRET

### DIFF
--- a/seafile-server/Dockerfile
+++ b/seafile-server/Dockerfile
@@ -28,7 +28,14 @@ python3-colorlog \
 python3-pymysql \
 python3-jinja2 \
 python3-sqlalchemy \
+python3-pip \
+python3-setuptools \
 && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --upgrade pip &&\
+pip3 install --timeout=3600 \
+pycryptodome==3.12.0 \
+&& rm -r /root/.cache/pip    
 
 ENV SEAFILE_VERSION=9.0.4
 

--- a/seafile-server/Dockerfile
+++ b/seafile-server/Dockerfile
@@ -28,14 +28,8 @@ python3-colorlog \
 python3-pymysql \
 python3-jinja2 \
 python3-sqlalchemy \
-python3-pip \
-python3-setuptools \
+python3-pycryptodome \
 && rm -rf /var/lib/apt/lists/*
-
-RUN python3 -m pip install --upgrade pip &&\
-pip3 install --timeout=3600 \
-pycryptodome==3.12.0 \
-&& rm -r /root/.cache/pip    
 
 ENV SEAFILE_VERSION=9.0.4
 


### PR DESCRIPTION
When 2FA login is activated, webdav does not work, because it does not support 2FA.
The option ENABLE_WEBDAV_SECRET enables a additional secret for WebDAV login.
This feature needs pycryptodome.

Without the pip module the login fails and the following error is generated:
`seafile-server_1     | 2022-03-26 21:13:14.506 - <140120687240960> wsgidav.dc.domain_controller WARNING :  Failed to login: No module named 'Crypto'`
The module is needed here: https://github.com/haiwen/seafdav/blob/02d153ff1a292b55e264b92e88a25b9f024c1f98/wsgidav/dc/domain_controller.py#L132
