### PR TITLE
SERVER_IP should be an ip or dns name, not a URL (upstream #368)

### DIFF
--- a/seafile-server/scripts/bootstrap.py
+++ b/seafile-server/scripts/bootstrap.py
@@ -55,7 +55,8 @@ def init_seafile_server():
     proto = 'https' if is_https() else 'http'
     env = {
         'SERVER_NAME': 'seafile',
-        'SERVER_IP': f'{proto}://{domain}',
+        'SERVER_IP': domain,
+        'FORCE_HTTPS_IN_CONF': 'true' if is_https() else 'false',
         'MYSQL_USER': 'seafile',
         'MYSQL_USER_PASSWD': str(uuid.uuid4()),
         'MYSQL_USER_HOST': '%.%.%.%',
@@ -71,8 +72,6 @@ def init_seafile_server():
         .format(get_script('setup-seafile-mysql.py')), shell=True)
     
     # Change setup-seafile-mysql.py to allow protocol (http/https) in SERVER_IP
-    call('''sed -i "/SERVER_IP_OR_DOMAIN_REGEX\ =/c\\ \ \ \ SERVER_IP_OR_DOMAIN_REGEX\ \=\ r'^(http:\\/\\/|https:\\/\\/)[^.].+\..+[^.]$'" {}'''
-        .format(get_script('setup-seafile-mysql.py')), shell=True)
     call('''sed -i '/SERVICE_URL = "http:\/\//s/http:\/\///' {}'''
         .format(get_script('setup-seafile-mysql.py')), shell=True)
 


### PR DESCRIPTION
Proposed fix for potentially incorrect URL vs IP/DNS modification

Tested by adding to `compose/docker-compose.yml`

```
services:
  seafile-server:
    image: ggogel/seafile-server:11.0.13
    volumes:
      - seafile-data:/shared
      - ../seafile-server/scripts/bootstrap.py:/scripts/bootstrap.py
```

Starting with `docker-compose up`

Checking with :

```
docker-compose exec seafile-server bash -c 'cat /opt/seafile/conf/seahub_settings.py | grep http'
SERVICE_URL = "https://seafile.mydomain.com"
FILE_SERVER_ROOT = "https://seafile.mydomain.com/seafhttp"
OFFICE_CONVERTOR_ROOT = 'http://127.0.0.1:6000/'
CSRF_TRUSTED_ORIGINS = ['https://seafile.mydomain.com']
```

The URL have the right URL scheme with no spurious scheme
